### PR TITLE
feat: Expose native http error instance on failure

### DIFF
--- a/src/https/request.ios.ts
+++ b/src/https/request.ios.ts
@@ -267,7 +267,7 @@ function AFFailure(resolve, reject, task: NSURLSessionDataTask, error: NSError, 
     const failingURL = error.userInfo.objectForKey('NSErrorFailingURLKey');
     if (useLegacy) {
         if (!sendi.statusCode) {
-            return reject(error.localizedDescription);
+            return reject(error);
         }
         const failure: any = {
             error,


### PR DESCRIPTION
This PR exposes the entire error instance for iOS legacy and closes #103 